### PR TITLE
Fix For Issue #26

### DIFF
--- a/src/assets/scenarios.json
+++ b/src/assets/scenarios.json
@@ -925,7 +925,7 @@
                 "treasure": {
                     "44": {
                         "looted": "false",
-                        "description": "Random Item Design"
+                        "description": "Random Side Scenario"
                     }
                 }
             },


### PR DESCRIPTION
The treasure reward read 'Random Item Design' when it should have read 'Random Side Scenario' instead.